### PR TITLE
Replace broken window.print() with html2pdf.js for PDF download

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
+        "html2pdf.js": "^0.14.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-icons": "^5.2.1",
@@ -1957,12 +1958,10 @@
       "integrity": "sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA=="
     },
     "node_modules/@babel/runtime": {
-      "version": "7.23.8",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.8.tgz",
-      "integrity": "sha512-Y7KbAP984rn1VGMbGqKmBLio9V7y5Je9GvU4rQPCPinCyNfUcToxIXl06d59URp/F3LwinvODxab5N/G6qggkw==",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -4889,6 +4888,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==",
+      "license": "MIT"
+    },
     "node_modules/@types/parse-json": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
@@ -4913,6 +4918,13 @@
       "version": "6.9.11",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.11.tgz",
       "integrity": "sha512-oGk0gmhnEJK4Yyk+oI7EfXsLayXatCWPHary1MtcmbAifkobT9cM9yutG/hZKIseOU0MqbIwQ/u2nn/Gb+ltuQ=="
+    },
+    "node_modules/@types/raf": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.7",
@@ -6181,6 +6193,15 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/batch": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
@@ -6457,6 +6478,26 @@
           "url": "https://github.com/sponsors/ai"
         }
       ]
+    },
+    "node_modules/canvg": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+      "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/case-sensitive-paths-webpack-plugin": {
       "version": "2.4.0",
@@ -6889,6 +6930,15 @@
       },
       "peerDependencies": {
         "postcss": "^8.4"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/css-loader": {
@@ -7582,6 +7632,15 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.1.tgz",
+      "integrity": "sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/domutils": {
@@ -8735,6 +8794,17 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
     },
+    "node_modules/fast-png": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/fast-png/-/fast-png-6.4.0.tgz",
+      "integrity": "sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/pako": "^2.0.3",
+        "iobuffer": "^5.3.2",
+        "pako": "^2.1.0"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.16.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.16.0.tgz",
@@ -8761,6 +8831,12 @@
       "dependencies": {
         "bser": "2.1.1"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
@@ -9775,6 +9851,30 @@
         }
       }
     },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/html2pdf.js": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/html2pdf.js/-/html2pdf.js-0.14.0.tgz",
+      "integrity": "sha512-yvNJgE/8yru2UeGflkPdjW8YEY+nDH5X7/2WG4uiuSCwYiCp8PZ8EKNiTAa6HxJ1NjC51fZSIEq6xld5CADKBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "dompurify": "^3.3.1",
+        "html2canvas": "^1.0.0",
+        "jspdf": "^4.0.0"
+      }
+    },
     "node_modules/htmlparser2": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
@@ -10030,6 +10130,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/iobuffer": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
+      "integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==",
+      "license": "MIT"
     },
     "node_modules/ipaddr.js": {
       "version": "2.1.0",
@@ -12726,6 +12832,23 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/jspdf": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.2.0.tgz",
+      "integrity": "sha512-hR/hnRevAXXlrjeqU5oahOE+Ln9ORJUB5brLHHqH67A+RBQZuFr5GkbI9XQI8OUFSEezKegsi45QRpc4bGj75Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "fast-png": "^6.2.0",
+        "fflate": "^0.8.1"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.11",
+        "core-js": "^3.6.0",
+        "dompurify": "^3.3.1",
+        "html2canvas": "^1.0.0-rc.5"
+      }
+    },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
@@ -13609,6 +13732,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+      "license": "(MIT AND Zlib)"
     },
     "node_modules/param-case": {
       "version": "3.0.4",
@@ -15367,11 +15496,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/react-app-polyfill/node_modules/regenerator-runtime": {
-      "version": "0.13.11",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
-    },
     "node_modules/react-dev-utils": {
       "version": "12.0.1",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-12.0.1.tgz",
@@ -15690,9 +15814,10 @@
       }
     },
     "node_modules/regenerator-runtime": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT"
     },
     "node_modules/regenerator-transform": {
       "version": "0.15.2",
@@ -15918,6 +16043,16 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.15"
       }
     },
     "node_modules/rimraf": {
@@ -16593,6 +16728,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/stackblur-canvas": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.14"
+      }
+    },
     "node_modules/stackframe": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
@@ -17087,6 +17232,16 @@
       "resolved": "https://registry.npmjs.org/svg-parser/-/svg-parser-2.0.4.tgz",
       "integrity": "sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ=="
     },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/svgo": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/svgo/-/svgo-1.3.2.tgz",
@@ -17333,6 +17488,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/text-table": {
@@ -17811,6 +17975,15 @@
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
       }
     },
     "node_modules/uuid": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
+    "html2pdf.js": "^0.14.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-icons": "^5.2.1",

--- a/src/components/Header.css
+++ b/src/components/Header.css
@@ -147,6 +147,20 @@
     transform: translateY(0);
 }
 
+.download-resume-btn:disabled {
+    opacity: 0.7;
+    cursor: wait;
+}
+
+.spin-icon {
+    animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+    from { transform: rotate(0deg); }
+    to { transform: rotate(360deg); }
+}
+
 .download-resume-btn .btn-text {
     transition: all 0.3s ease;
 }

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,14 +1,56 @@
 // src/components/Header.js
 
-import React, { useState, useEffect, useRef } from "react";
+import React, { useState, useEffect, useRef, useCallback } from "react";
 import "./Header.css";
-import {FaEnvelope, FaLinkedin, FaGithub, FaMapMarkerAlt, FaPhone, FaDownload, FaGlobe} from "react-icons/fa";
+import {FaEnvelope, FaLinkedin, FaGithub, FaMapMarkerAlt, FaPhone, FaDownload, FaGlobe, FaSpinner} from "react-icons/fa";
 
 function Header() {
     const [scrolled, setScrolled] = useState(false);
+    const [generating, setGenerating] = useState(false);
     const lastScrollY = useRef(0);
     const timeoutRef = useRef(null);
     const lastChangeTime = useRef(0);
+
+    const handleDownloadPDF = useCallback(async () => {
+        if (generating) return;
+        setGenerating(true);
+
+        try {
+            const html2pdf = (await import('html2pdf.js')).default;
+
+            // Apply PDF mode styles
+            document.body.classList.add('pdf-mode');
+
+            // Wait for styles to apply
+            await new Promise(resolve => setTimeout(resolve, 200));
+
+            const element = document.querySelector('.App');
+
+            const opt = {
+                margin: [8, 5, 8, 5],
+                filename: 'Ven_Tsochev_Resume.pdf',
+                image: { type: 'jpeg', quality: 0.98 },
+                html2canvas: {
+                    scale: 2,
+                    useCORS: true,
+                    letterRendering: true,
+                    scrollY: 0,
+                    windowWidth: 1000,
+                },
+                jsPDF: { unit: 'mm', format: 'a4', orientation: 'portrait' },
+                pagebreak: { mode: ['avoid-all', 'css', 'legacy'] },
+            };
+
+            await html2pdf().set(opt).from(element).save();
+        } catch (err) {
+            console.error('PDF generation failed:', err);
+            // Fallback to browser print
+            window.print();
+        } finally {
+            document.body.classList.remove('pdf-mode');
+            setGenerating(false);
+        }
+    }, [generating]);
 
     useEffect(() => {
         const handleScroll = () => {
@@ -82,8 +124,8 @@ function Header() {
                         <a href="https://sentifi.xyz" target="_blank" rel="noopener noreferrer" className="social-link" title="Portfolio - SentiFi AI">
                             <FaGlobe />
                         </a>
-                        <button onClick={() => window.print()} className="download-resume-btn" title="Print / Download Resume">
-                            <FaDownload /> <span className="btn-text">Resume</span>
+                        <button onClick={handleDownloadPDF} className="download-resume-btn" title="Download Resume as PDF" disabled={generating}>
+                            {generating ? <FaSpinner className="spin-icon" /> : <FaDownload />} <span className="btn-text">{generating ? 'Generating...' : 'Resume'}</span>
                         </button>
                     </div>
                 </div>

--- a/src/print.css
+++ b/src/print.css
@@ -1,243 +1,236 @@
-/* Print Styles for Resume Download/Print */
+/* PDF/Print Styles for Resume Download */
+/* .pdf-mode is applied during html2pdf capture */
+/* @media print is fallback for browser Ctrl+P */
 
+/* ===== Hide non-content elements ===== */
+.pdf-mode .header-nav,
+.pdf-mode .scroll-to-top,
+.pdf-mode .download-resume-btn,
+.pdf-mode .skip-link,
+.pdf-mode .expand-icon,
+.pdf-mode .experience-icon,
+.pdf-mode .projects,
+.pdf-mode footer {
+    display: none !important;
+}
+
+/* ===== Force all animations visible ===== */
+.pdf-mode .animated-section {
+    opacity: 1 !important;
+    transform: none !important;
+}
+
+/* ===== Base resets ===== */
+.pdf-mode,
+.pdf-mode .App {
+    background: white !important;
+    background-image: none !important;
+}
+
+.pdf-mode .App::before {
+    display: none !important;
+}
+
+.pdf-mode main {
+    padding: 0 !important;
+    margin: 0 !important;
+}
+
+/* ===== Header ===== */
+.pdf-mode .header {
+    position: relative !important;
+    padding: 8px 0 12px 0 !important;
+    box-shadow: none !important;
+    border-bottom: 2px solid #000 !important;
+    background: white !important;
+    color: black !important;
+    backdrop-filter: none !important;
+}
+
+.pdf-mode .header * {
+    color: black !important;
+}
+
+.pdf-mode .header-main {
+    margin-bottom: 8px !important;
+}
+
+.pdf-mode .header-info h1 {
+    -webkit-text-fill-color: black !important;
+    background: none !important;
+    font-size: 1.8em !important;
+    margin-bottom: 4px !important;
+}
+
+.pdf-mode .header-info .title {
+    font-size: 1.1em !important;
+    margin-bottom: 6px !important;
+    opacity: 1 !important;
+    max-height: none !important;
+    color: #333 !important;
+}
+
+.pdf-mode .contact-quick {
+    opacity: 1 !important;
+    max-height: none !important;
+    display: flex !important;
+    font-size: 0.85em !important;
+    margin-bottom: 0 !important;
+}
+
+.pdf-mode .header-social {
+    display: none !important;
+}
+
+/* ===== Sections ===== */
+.pdf-mode section {
+    background: white !important;
+    color: black !important;
+    padding: 12px 0 8px 0 !important;
+    margin-bottom: 8px !important;
+    backdrop-filter: none !important;
+}
+
+.pdf-mode section * {
+    color: black !important;
+}
+
+.pdf-mode .section-title {
+    color: #222 !important;
+    border-bottom: 2px solid #4CAF50;
+    padding-bottom: 6px !important;
+    margin-bottom: 12px !important;
+    font-size: 1.6em !important;
+}
+
+.pdf-mode .container {
+    padding: 0 15px !important;
+}
+
+/* ===== Experience - force ALL items expanded ===== */
+.pdf-mode .experience-item {
+    opacity: 1 !important;
+    background-color: white !important;
+    border: 1px solid #ddd !important;
+    border-left: 3px solid #4CAF50 !important;
+    margin-bottom: 10px !important;
+    padding: 12px 15px !important;
+    border-radius: 0 !important;
+}
+
+.pdf-mode .responsibilities,
+.pdf-mode .responsibilities.hide,
+.pdf-mode .responsibilities.show {
+    display: block !important;
+    opacity: 1 !important;
+    max-height: none !important;
+    animation: none !important;
+    padding: 0 !important;
+    margin: 8px 0 0 0 !important;
+    overflow: visible !important;
+}
+
+.pdf-mode .responsibilities li {
+    font-size: 0.88em !important;
+    line-height: 1.5 !important;
+    margin-bottom: 5px !important;
+    padding-left: 18px !important;
+    color: #333 !important;
+}
+
+.pdf-mode .responsibilities li:before {
+    color: #4CAF50 !important;
+}
+
+.pdf-mode .experience-header {
+    margin-bottom: 8px !important;
+    cursor: default !important;
+}
+
+.pdf-mode .experience-item h3 {
+    font-size: 1.2em !important;
+    margin-bottom: 2px !important;
+    color: black !important;
+}
+
+.pdf-mode .company-info {
+    font-size: 0.95em !important;
+    margin-bottom: 2px !important;
+    color: #333 !important;
+}
+
+.pdf-mode .period {
+    font-size: 0.85em !important;
+    color: #555 !important;
+    margin: 0 !important;
+}
+
+/* ===== Skills ===== */
+.pdf-mode .skill-category {
+    margin-bottom: 10px !important;
+}
+
+.pdf-mode .skills-grid,
+.pdf-mode .certificates-grid,
+.pdf-mode .languages-grid {
+    gap: 8px !important;
+}
+
+.pdf-mode .skill-badge {
+    border: 1px solid #ddd !important;
+    background: white !important;
+    color: black !important;
+    padding: 3px 8px !important;
+    margin: 2px !important;
+    font-size: 0.82em !important;
+}
+
+/* ===== Cards ===== */
+.pdf-mode .certificate-card,
+.pdf-mode .education-card,
+.pdf-mode .language-card {
+    background: white !important;
+    border: 1px solid #ddd !important;
+    margin-bottom: 8px !important;
+    padding: 10px !important;
+}
+
+/* ===== Global resets ===== */
+.pdf-mode * {
+    box-shadow: none !important;
+    text-shadow: none !important;
+}
+
+.pdf-mode a {
+    color: #0066cc !important;
+    text-decoration: none !important;
+}
+
+.pdf-mode .contact-link {
+    color: black !important;
+}
+
+/* ===== Fallback: browser print (Ctrl+P) ===== */
 @media print {
-    /* Hide elements not needed in print */
-    .header-nav,
-    .scroll-to-top,
-    .download-resume-btn,
-    .skip-link,
-    .expand-icon,
-    .experience-icon,
-    .projects,
-    footer {
-        display: none !important;
-    }
-
-    /* Ensure all sections are visible in print */
-    .animated-section {
-        opacity: 1 !important;
-        transform: none !important;
-    }
-
-    /* Compact header for print - trim spacing */
-    .header {
-        position: relative;
-        padding: 5px 0 10px 0 !important;
-        box-shadow: none;
-        border-bottom: 2px solid #000;
-        background: white !important;
-        color: black !important;
-        margin-bottom: 10px !important;
-    }
-
-    .header * {
-        color: black !important;
-    }
-
-    .header-main {
-        margin-bottom: 8px !important;
-    }
-
-    .header-info h1 {
-        -webkit-text-fill-color: black !important;
-        font-size: 1.8em !important;
-        margin-bottom: 4px !important;
-    }
-
-    .header-info .title {
-        font-size: 1.1em !important;
-        margin-bottom: 6px !important;
-        opacity: 1 !important;
-        max-height: none !important;
-    }
-
-    .contact-quick {
-        opacity: 1 !important;
-        max-height: none !important;
-        display: flex !important;
-        font-size: 0.85em !important;
-        margin-bottom: 0 !important;
-    }
-
-    .header-social {
-        display: none;
-    }
-
-    /* Optimize spacing for print */
-    body {
-        background: white;
-        color: black;
-    }
-
-    .App {
-        background: white !important;
-    }
-
-    .App::before {
-        display: none;
-    }
-
-    main {
-        padding: 0 !important;
-        margin: 0 !important;
-    }
-
-    /* Section styling for print - reduce spacing */
-    section {
-        page-break-inside: avoid;
-        background: white !important;
-        color: black !important;
-        padding: 15px 0 10px 0 !important;
-        margin-bottom: 10px !important;
-    }
-
-    section * {
-        color: black !important;
-    }
-
-    .section-title {
-        color: black !important;
-        border-bottom: 2px solid #4CAF50;
-        padding-bottom: 8px !important;
-        margin-bottom: 15px !important;
-        font-size: 1.8em !important;
-    }
-
-    .container {
-        padding: 0 15px !important;
-    }
-
-    /* CRITICAL: Force ALL experience items to be expanded */
-    .experience-item {
-        opacity: 1 !important;
-        background-color: white !important;
-        border: 1px solid #ddd !important;
-        margin-bottom: 12px !important;
-        padding: 15px !important;
-        page-break-inside: avoid;
-    }
-
-    /* Remove collapsed class effects */
-    .experience-item.collapsed {
-        opacity: 1 !important;
-        background-color: white !important;
-    }
-
-    /* Force expanded state */
-    .experience-item.expanded {
-        opacity: 1 !important;
-        background-color: white !important;
-    }
-
-    /* CRITICAL: Always show responsibilities - override hide class */
-    .responsibilities,
-    .responsibilities.hide,
-    .responsibilities.show {
-        display: block !important;
-        opacity: 1 !important;
-        max-height: none !important;
-        animation: none !important;
-        padding: 0 !important;
-        margin: 10px 0 0 0 !important;
-        overflow: visible !important;
-    }
-
-    .responsibilities li {
-        font-size: 0.9em !important;
-        line-height: 1.5 !important;
-        margin-bottom: 6px !important;
-        padding-left: 20px !important;
-        color: black !important;
-    }
-
-    .responsibilities li:before {
-        color: #4CAF50 !important;
-    }
-
-    /* Experience header spacing */
-    .experience-header {
-        margin-bottom: 10px !important;
-        cursor: default !important;
-    }
-
-    .experience-item.collapsed .experience-header {
-        margin-bottom: 10px !important;
-    }
-
-    .experience-item.expanded .experience-header {
-        margin-bottom: 10px !important;
-    }
-
-    .experience-item h3 {
-        font-size: 1.3em !important;
-        margin-bottom: 4px !important;
-        color: black !important;
-    }
-
-    .company-info {
-        font-size: 1em !important;
-        margin-bottom: 4px !important;
-        color: black !important;
-    }
-
-    .period {
-        font-size: 0.9em !important;
-        color: #555 !important;
-        margin: 0 !important;
-    }
-
-    /* Other sections - compact spacing */
-    .certificate-card,
-    .education-card,
-    .language-card {
-        page-break-inside: avoid;
-        background: white !important;
-        border: 1px solid #ddd !important;
-        margin-bottom: 10px !important;
-        padding: 12px !important;
-    }
-
-    .skill-category {
-        margin-bottom: 12px !important;
-    }
-
-    .skills-grid,
-    .certificates-grid,
-    .languages-grid {
-        gap: 10px !important;
-    }
-
-    /* Remove unnecessary backgrounds and effects */
-    * {
-        background: white !important;
-        box-shadow: none !important;
-        text-shadow: none !important;
-    }
-
-    /* Ensure links are visible */
-    a {
-        color: #0066cc !important;
-        text-decoration: underline;
-    }
-
-    .contact-link {
-        color: black !important;
-        text-decoration: none !important;
-    }
-
-    /* Skill badges for print */
-    .skill-badge {
-        border: 1px solid #ddd !important;
-        background: white !important;
-        color: black !important;
-        padding: 4px 10px !important;
-        margin: 3px !important;
-        font-size: 0.85em !important;
-    }
-
-    /* Page settings */
-    @page {
-        margin: 1.5cm 1cm;
-        size: A4;
-    }
+    body { background: white; color: black; }
+    .header-nav, .scroll-to-top, .download-resume-btn,
+    .skip-link, .expand-icon, .experience-icon,
+    .projects, footer { display: none !important; }
+    .animated-section { opacity: 1 !important; transform: none !important; }
+    .App { background: white !important; }
+    .App::before { display: none !important; }
+    .header { position: relative; background: white !important;
+        box-shadow: none; border-bottom: 2px solid #000; }
+    .header * { color: black !important; }
+    .header-info h1 { -webkit-text-fill-color: black !important; }
+    .header-info .title { opacity: 1 !important; max-height: none !important; }
+    .contact-quick { opacity: 1 !important; max-height: none !important; }
+    .header-social { display: none; }
+    section { background: white !important; color: black !important; }
+    section * { color: black !important; }
+    .responsibilities, .responsibilities.hide, .responsibilities.show {
+        display: block !important; opacity: 1 !important;
+        max-height: none !important; overflow: visible !important; }
+    * { box-shadow: none !important; text-shadow: none !important; }
+    @page { margin: 1.5cm 1cm; size: A4; }
 }


### PR DESCRIPTION
- Install html2pdf.js for client-side PDF generation
- Capture the DOM visually instead of relying on browser print CSS
- Add .pdf-mode class that applies clean white-background styles and forces all collapsed experience sections visible
- Show spinner + "Generating..." state while PDF is being created
- Fallback to window.print() if html2pdf fails
- Keep @media print styles as Ctrl+P fallback